### PR TITLE
keepRemainder option and v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,31 @@ Wreck.request('get', 'https://api.npms.io/v2/search?q=streams&size=100', null, (
 ```
 
 ## API
-### `new Clowncar([pathToArray], [doParse])`
+### `new Clowncar([options])`
 
-Returns a new [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform), which will receive streaming JSON and output the items of an array within that JSON where,
+Returns a new [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform), which will receive streaming JSON and output the items of an array within that JSON where `options` is either,
 
- - `pathToArray` - a path in the form of an array or [`Hoek.reach()`](https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options)-style string, specifying where in the incoming JSON the array will be found.  Defaults to `[]`, meaning that the incoming JSON is the array itself.
+ - an array or string specifying `pathToArray` as described below or,
+ - an object of the form,
+   - `pathToArray` - a path in the form of an array or [`Hoek.reach()`](https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options)-style string, specifying where in the incoming JSON the array will be found.  Defaults to `[]`, meaning that the incoming JSON is the array itself.
 
- For example, `['a', 1, 'b']` and `'a.1.b'` both represent the array `["this", "array"]` within the following JSON,
+     For example, `['a', 1, 'b']` and `'a.1.b'` both represent the array `["this", "array"]` within the following JSON,
 
- ```json
-  {
-    "a": [
-      "junk",
+     ```json
       {
-        "b": ["this", "array"]
-      },
-      "junk"
-    ]
-  }
-```
+        "a": [
+          "junk",
+          {
+            "b": ["this", "array"]
+          },
+          "junk"
+        ]
+      }
+     ```
 
-- `doParse` - a boolean specifying whether the outgoing array items will be parsed (with `JSON.parse()`), or left as buffers.  Defaults to `true`.  When `true`, the stream is placed into object mode.
+   - `keepRemainder` - a boolean specifying whether the remainder of the incoming JSON (omitting the array items at `pathToArray`) should be emitted after the stream ends.  When `true` a `'remainder'` event is emitted after the `'end'` event with a single argument containing the remainder.  Defaults to `false`.
+
+   - `doParse` - a boolean specifying whether the outgoing array items and remainder should be parsed (with `JSON.parse()`), or left as buffers.  Defaults to `true`.  When `true`, the stream is placed into object mode.
 
 ## Extras
 ### Approach

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,12 +80,13 @@ module.exports = class Clowncar extends Stream.Transform {
 
         if (this.keepRemainder) {
             const remainder = Buffer.concat(this._remainder);
+            const emit = this.emit.bind(this);
 
             if (remainder.length === 0) {
-                return this.emit('remainder');
+                return process.nextTick(emit, 'remainder');
             }
 
-            this.emit('remainder', this._maybeParse(remainder));
+            process.nextTick(emit, 'remainder', this._maybeParse(remainder));
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,31 @@
 'use strict';
 
 const Stream = require('stream');
+const BufferFrom = require('buffer-from');
 const JsonDepthStream = require('json-depth-stream');
 
 const internals = {};
 
 module.exports = class Clowncar extends Stream.Transform {
 
-    constructor(pathToArray, doParse) {
+    constructor(options) {
 
-        if (typeof pathToArray === 'boolean') {
-            doParse = pathToArray;
-            pathToArray = null;
+        options = options || {};
+
+        if (Array.isArray(options) || typeof options === 'string') {
+            options = { pathToArray: options };
         }
 
-        pathToArray = pathToArray ? internals.normalizePathToArray(pathToArray) : [];
-        doParse = (typeof doParse === 'undefined') ? true : !!doParse;
+        const pathToArray = options.pathToArray ? internals.normalizePathToArray(options.pathToArray) : [];
+        const doParse = (typeof options.doParse === 'undefined') ? true : !!options.doParse;
+        const keepRemainder = !!options.keepRemainder;
 
         // We gonna send buffers or parsed JSON?
         super({ readableObjectMode: doParse });
 
         this.pathToArray = pathToArray;
         this.doParse = doParse;
+        this.keepRemainder = keepRemainder;
         this._endedEarly = false;
         this._depth = this.pathToArray.length + 1;
         this._jsonStream = new JsonDepthStream(this._depth);
@@ -40,7 +44,7 @@ module.exports = class Clowncar extends Stream.Transform {
 
     write(chk, enc, cb) {
 
-        if (this._endedEarly) {
+        if (this._endedEarly && !this.keepRemainder) {
             return false;
         }
 
@@ -61,7 +65,7 @@ module.exports = class Clowncar extends Stream.Transform {
                 this._backlog.chunks.push(this._currentChunk);
             }
             else {
-                this._remainder.push(this._currentChunk);
+                this._maybeKeepRemainder(this._currentChunk);
             }
         }
 
@@ -70,15 +74,33 @@ module.exports = class Clowncar extends Stream.Transform {
 
     _cleanup() {
 
-        console.log(JSON.parse(Buffer.concat(this._remainder).toString()));
         this._jsonStream.removeListener('split', this._boundSplit);
         this._currentChunk = null;
         this._backlog = null;
+
+        if (this.keepRemainder) {
+            const remainder = Buffer.concat(this._remainder);
+
+            if (remainder.length === 0) {
+                return this.emit('remainder');
+            }
+
+            this.emit('remainder', this._maybeParse(remainder));
+        }
     }
 
     _maybeParse(itemBuffer) {
 
         return this.doParse ? JSON.parse(itemBuffer.toString()) : itemBuffer;
+    }
+
+    _maybeKeepRemainder(bufferOrStr) {
+
+        if (!this.keepRemainder) {
+            return;
+        }
+
+        this._remainder.push((typeof bufferOrStr === 'string') ? BufferFrom(bufferOrStr) : bufferOrStr);
     }
 
     _split(path, index) {
@@ -97,15 +119,19 @@ module.exports = class Clowncar extends Stream.Transform {
         // This means we're done.
 
         if (path.length !== this._depth) {
-            this._remainder.push(this._currentChunk.slice(index));
+            this._maybeKeepRemainder(this._currentChunk.slice(index));
             this._endedEarly = true;
-            //return this.end();
+
+            if (!this.keepRemainder) {
+                this.end();
+            }
+
             return;
         }
 
         if (!this._startedParsingArray) {
-            this._remainder.push(this._currentChunk.slice(0, index - 1));
-            this._remainder.push(Buffer.from('null'));
+            this._maybeKeepRemainder(this._currentChunk.slice(0, index));
+            this._maybeKeepRemainder(']'); // Close opened array
             this._startedParsingArray = true;
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ module.exports = class Clowncar extends Stream.Transform {
         this._hadSplit = false;
         this._hasStartedItem = false;
         this._currentChunk = null;
+        this._remainder = [];
         this._startedParsingArray = false;
         this._backlog = { start: null, buffers: [] };
         this._boundSplit = this._split.bind(this);
@@ -55,8 +56,13 @@ module.exports = class Clowncar extends Stream.Transform {
 
         // Now zero or many splits may occur due to update(), causing pushes in sync
 
-        if (!this._hadSplit && this._hasStartedItem) {
-            this._backlog.chunks.push(this._currentChunk);
+        if (!this._hadSplit) {
+            if (this._hasStartedItem) {
+                this._backlog.chunks.push(this._currentChunk);
+            }
+            else {
+                this._remainder.push(this._currentChunk);
+            }
         }
 
         return cb();
@@ -64,6 +70,7 @@ module.exports = class Clowncar extends Stream.Transform {
 
     _cleanup() {
 
+        console.log(JSON.parse(Buffer.concat(this._remainder).toString()));
         this._jsonStream.removeListener('split', this._boundSplit);
         this._currentChunk = null;
         this._backlog = null;
@@ -90,11 +97,17 @@ module.exports = class Clowncar extends Stream.Transform {
         // This means we're done.
 
         if (path.length !== this._depth) {
+            this._remainder.push(this._currentChunk.slice(index));
             this._endedEarly = true;
-            return this.end();
+            //return this.end();
+            return;
         }
 
-        this._startedParsingArray = true;
+        if (!this._startedParsingArray) {
+            this._remainder.push(this._currentChunk.slice(0, index - 1));
+            this._remainder.push(Buffer.from('null'));
+            this._startedParsingArray = true;
+        }
 
         if (this._hasStartedItem) {
             if (this._backlog.chunks.length === 1 && this._backlog.chunks[0] === this._currentChunk) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/devinivy/clowncar#readme",
   "dependencies": {
+    "buffer-from": "0.1.x",
     "json-depth-stream": ">=2.1.0 <3"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,7 @@ describe('Clowncar', () => {
 
     it('outputs streaming JSON array items as buffers.', (done) => {
 
-        const clowncar = new Clowncar(false);
+        const clowncar = new Clowncar({ doParse: false });
         const stream = new Stream.PassThrough();
 
         setImmediate(() => {
@@ -93,7 +93,10 @@ describe('Clowncar', () => {
 
     it('can stream parsed items as buffers from a deep array.', (done) => {
 
-        const clowncar = new Clowncar(['a', 1, 'b'], false);
+        const clowncar = new Clowncar({
+            pathToArray: ['a', 1, 'b'],
+            doParse: false
+        });
         const stream = new Stream.PassThrough();
 
         setImmediate(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -190,7 +190,7 @@ describe('Clowncar', () => {
 
         setImmediate(() => {
 
-            stream.write('{"a":{"c":[6,6,6],"b":[0,"safe",0],"d":[6,6,6]}');
+            stream.write('{"a":{"c":[6,6,6],"b":[0,"safe",0],"d":[6,6,6]}}');
             stream.end();
         });
 
@@ -212,7 +212,7 @@ describe('Clowncar', () => {
 
         setImmediate(() => {
 
-            stream.write('{"a":[0,0,{"b":[1,2,3]}]');
+            stream.write('{"a":[0,0,{"b":[1,2,3]}]}');
             stream.end();
         });
 


### PR DESCRIPTION
 Firstly, this updates the format of constructor arguments.  Now `doParse` will be passed in a new `options` object rather than as a second argument.  Secondly, this adds a new `keepRemainder` option, description of which can be found in changes to the readme.